### PR TITLE
feat: P4ADEV-4528 enable PU as SEND hub

### DIFF
--- a/openapi/generated.openapi.json
+++ b/openapi/generated.openapi.json
@@ -1652,7 +1652,7 @@
             "format" : "date-time"
           }
         },
-        "required" : [ "debtPositionId", "navList" ]
+        "required" : [ "navList" ]
       },
       "LegalFactIdDTO" : {
         "type" : "object",

--- a/openapi/p4pa-send-notification.openapi.yaml
+++ b/openapi/p4pa-send-notification.openapi.yaml
@@ -793,7 +793,6 @@ components:
     SendNotificationPaymentsDTO:
       type: object
       required:
-        - debtPositionId
         - navList
       properties:
         debtPositionId:

--- a/src/main/java/it/gov/pagopa/pu/send/connector/organization/client/OrganizationApiClient.java
+++ b/src/main/java/it/gov/pagopa/pu/send/connector/organization/client/OrganizationApiClient.java
@@ -7,6 +7,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
 
+import java.util.Optional;
+
 @Slf4j
 @Service
 public class OrganizationApiClient {
@@ -34,6 +36,16 @@ public class OrganizationApiClient {
     } catch (HttpClientErrorException.NotFound e){
       log.info("Cannot find organization having organizationId {}", organizationId);
       return null;
+    }
+  }
+
+  public Optional<Organization> findByOrgFiscalCodeAndSegregationCode(String orgFiscalCode, String segregationCode, String accessToken) {
+    try{
+      return Optional.of(organizationApisHolder.getOrganizationSearchControllerApi(accessToken)
+        .crudOrganizationsFindByOrgFiscalCodeAndSegregationCode(orgFiscalCode, segregationCode));
+    } catch (HttpClientErrorException.NotFound e){
+      log.info("Cannot find organization having orgFiscalCode {} and segregationCode {}", orgFiscalCode, segregationCode);
+      return Optional.empty();
     }
   }
 

--- a/src/main/java/it/gov/pagopa/pu/send/connector/organization/config/OrganizationApisHolder.java
+++ b/src/main/java/it/gov/pagopa/pu/send/connector/organization/config/OrganizationApisHolder.java
@@ -3,6 +3,7 @@ package it.gov.pagopa.pu.send.connector.organization.config;
 import it.gov.pagopa.pu.organization.client.generated.BrokerSearchControllerApi;
 import it.gov.pagopa.pu.organization.client.generated.OrganizationApi;
 import it.gov.pagopa.pu.organization.client.generated.OrganizationEntityControllerApi;
+import it.gov.pagopa.pu.organization.client.generated.OrganizationSearchControllerApi;
 import it.gov.pagopa.pu.organization.generated.ApiClient;
 import it.gov.pagopa.pu.organization.generated.BaseApi;
 import it.gov.pagopa.pu.send.config.rest.RestTemplateConfig;
@@ -17,6 +18,7 @@ public class OrganizationApisHolder {
   private final OrganizationApi organizationApi;
   private final OrganizationEntityControllerApi organizationEntityControllerApi;
   private final BrokerSearchControllerApi brokerSearchControllerApi;
+  private final OrganizationSearchControllerApi organizationSearchControllerApi;
   private final ThreadLocal<String> bearerTokenHolder = new ThreadLocal<>();
 
   public OrganizationApisHolder(OrganizationApiClientConfig clientConfig, RestTemplateBuilder restTemplateBuilder) {
@@ -30,6 +32,7 @@ public class OrganizationApisHolder {
     this.organizationApi = new OrganizationApi(apiClient);
     this.organizationEntityControllerApi = new OrganizationEntityControllerApi(apiClient);
     this.brokerSearchControllerApi = new BrokerSearchControllerApi(apiClient);
+    this.organizationSearchControllerApi = new OrganizationSearchControllerApi(apiClient);
   }
 
   @PreDestroy
@@ -47,6 +50,10 @@ public class OrganizationApisHolder {
 
   public BrokerSearchControllerApi getBrokerSearchControllerApi(String accessToken) {
     return getApi(accessToken, brokerSearchControllerApi);
+  }
+
+  public  OrganizationSearchControllerApi getOrganizationSearchControllerApi(String accessToken) {
+    return getApi(accessToken, organizationSearchControllerApi);
   }
 
   private ApiClient buildApiClient(RestTemplate restTemplate, OrganizationApiClientConfig clientConfig) {

--- a/src/main/java/it/gov/pagopa/pu/send/connector/organization/service/OrganizationService.java
+++ b/src/main/java/it/gov/pagopa/pu/send/connector/organization/service/OrganizationService.java
@@ -2,8 +2,11 @@ package it.gov.pagopa.pu.send.connector.organization.service;
 
 import it.gov.pagopa.pu.organization.dto.generated.Organization;
 
+import java.util.Optional;
+
 public interface OrganizationService {
 
   String getOrganizationApiKey(Long organizationId, String accessToken);
   Organization getOrganization(Long organizationId, String accessToken);
+  Optional<Organization> findByOrgFiscalCodeAndSegregationCode(String orgFiscalCode, String segregationCode, String accessToken);
 }

--- a/src/main/java/it/gov/pagopa/pu/send/connector/organization/service/OrganizationServiceImpl.java
+++ b/src/main/java/it/gov/pagopa/pu/send/connector/organization/service/OrganizationServiceImpl.java
@@ -4,6 +4,8 @@ import it.gov.pagopa.pu.organization.dto.generated.Organization;
 import it.gov.pagopa.pu.send.connector.organization.client.OrganizationApiClient;
 import org.springframework.stereotype.Service;
 
+import java.util.Optional;
+
 @Service
 public class OrganizationServiceImpl implements OrganizationService {
 
@@ -21,5 +23,10 @@ public class OrganizationServiceImpl implements OrganizationService {
   @Override
   public Organization getOrganization(Long organizationId, String accessToken){
     return organizationApiClient.findByOrganizationId(organizationId, accessToken);
+  }
+
+  @Override
+  public Optional<Organization> findByOrgFiscalCodeAndSegregationCode(String orgFiscalCode, String segregationCode, String accessToken) {
+    return organizationApiClient.findByOrgFiscalCodeAndSegregationCode(orgFiscalCode, segregationCode, accessToken);
   }
 }

--- a/src/main/java/it/gov/pagopa/pu/send/mapper/CreateNotificationRequest2SendNotificationMapper.java
+++ b/src/main/java/it/gov/pagopa/pu/send/mapper/CreateNotificationRequest2SendNotificationMapper.java
@@ -2,6 +2,7 @@ package it.gov.pagopa.pu.send.mapper;
 
 import it.gov.pagopa.pu.debtposition.dto.generated.DebtPositionDTO;
 import it.gov.pagopa.pu.organization.dto.generated.Broker;
+import it.gov.pagopa.pu.organization.dto.generated.Organization;
 import it.gov.pagopa.pu.send.connector.debtpositions.service.DebtPositionService;
 import it.gov.pagopa.pu.send.connector.organization.service.BrokerService;
 import it.gov.pagopa.pu.send.connector.organization.service.OrganizationService;
@@ -21,6 +22,7 @@ import org.springframework.stereotype.Service;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 @Service
@@ -53,7 +55,7 @@ public class CreateNotificationRequest2SendNotificationMapper {
       sendNotification.setStatus(NotificationStatus.WAITING_FILE);
     }
 
-    sendNotification.setPuRecipients(setPuRecipients(request, accessToken, organizationId));
+    sendNotification.setPuRecipients(setPuRecipients(request, accessToken));
     sendNotification.setDocuments(setDocuments(request));
 
     sendNotification.setOrganizationId(organizationId);
@@ -84,11 +86,11 @@ public class CreateNotificationRequest2SendNotificationMapper {
     return sendNotification;
   }
 
-  private List<PuRecipient> setPuRecipients(CreateNotificationRequest request, String accessToken, Long organizationId) {
+  private List<PuRecipient> setPuRecipients(CreateNotificationRequest request, String accessToken) {
     return request.getRecipients().stream()
       .map(r -> {
         List<PuPayment> puPayments = r.getPayments().stream()
-          .map(p -> getPuPayment(accessToken, organizationId, p)).toList();
+          .map(p -> getPuPayment(accessToken, p)).toList();
         Recipient recipient = Recipient.builder()
           .recipientType(r.getRecipientType())
           .taxId(r.getTaxId())
@@ -100,19 +102,17 @@ public class CreateNotificationRequest2SendNotificationMapper {
       }).toList();
   }
 
-  private PuPayment getPuPayment(String accessToken, Long organizationId, Payment p) {
+  private PuPayment getPuPayment(String accessToken, Payment p) {
     if (p.getPagoPa() != null) {
-      String nav = p.getPagoPa().getNoticeCode();
       String orgFiscalCode = p.getPagoPa().getCreditorTaxId();
-      if(isDebtPositionManagedByPU(orgFiscalCode, nav, accessToken)) {
-        DebtPositionDTO debtPosition = debtPositionService.findDebtPositionByInstallment(organizationId, nav, accessToken);
-        if (debtPosition == null) {
-          throw new UnknownDebtPositionException("[DEBT_POSITION_NOT_FOUND] Cannot find debtPosition related to organizationId " + organizationId + " and having an Installment with NAV " + nav);
-        } else {
-          return new PuPayment(debtPosition.getDebtPositionId(), p, null);
-        }
-      }
-      return new PuPayment(null, p, null);
+      String nav = p.getPagoPa().getNoticeCode();
+      String segregationCode = DebtPositionUtils.extractSegregationCodeFromNav(nav);
+      Optional<Organization> optionalOrganizationManagedByPU =
+        organizationService.findByOrgFiscalCodeAndSegregationCode(orgFiscalCode, segregationCode, accessToken);
+      return optionalOrganizationManagedByPU
+        .map(Organization::getOrganizationId)
+        .map(organizationId -> getPuPaymentWithDebtPositionId(p, nav, organizationId, accessToken))
+        .orElseGet(() -> new PuPayment(null, p, null));
     }
     if (p.getF24() != null) {
       return new PuPayment(null, p, null);
@@ -120,12 +120,13 @@ public class CreateNotificationRequest2SendNotificationMapper {
     return null;
   }
 
-  private boolean isDebtPositionManagedByPU(String orgFiscalCode, String nav, String accessToken) {
-    return organizationService.findByOrgFiscalCodeAndSegregationCode(
-      orgFiscalCode,
-      DebtPositionUtils.extractSegregationCodeFromNav(nav),
-      accessToken
-    ).isPresent();
+  private PuPayment getPuPaymentWithDebtPositionId(Payment p, String nav, Long organizationId, String accessToken) {
+    DebtPositionDTO debtPosition = debtPositionService.findDebtPositionByInstallment(organizationId, nav, accessToken);
+    if (debtPosition == null) {
+      throw new UnknownDebtPositionException("[DEBT_POSITION_NOT_FOUND] Cannot find debtPosition related to organizationId " + organizationId + " and having an Installment with NAV " + nav);
+    } else {
+      return new PuPayment(debtPosition.getDebtPositionId(), p, null);
+    }
   }
 
   private List<DocumentDTO> setDocuments(CreateNotificationRequest request) {

--- a/src/main/java/it/gov/pagopa/pu/send/mapper/CreateNotificationRequest2SendNotificationMapper.java
+++ b/src/main/java/it/gov/pagopa/pu/send/mapper/CreateNotificationRequest2SendNotificationMapper.java
@@ -112,7 +112,7 @@ public class CreateNotificationRequest2SendNotificationMapper {
           return new PuPayment(debtPosition.getDebtPositionId(), p, null);
         }
       }
-      return null;
+      return new PuPayment(null, p, null);
     }
     if (p.getF24() != null) {
       return new PuPayment(null, p, null);

--- a/src/main/java/it/gov/pagopa/pu/send/mapper/CreateNotificationRequest2SendNotificationMapper.java
+++ b/src/main/java/it/gov/pagopa/pu/send/mapper/CreateNotificationRequest2SendNotificationMapper.java
@@ -4,6 +4,7 @@ import it.gov.pagopa.pu.debtposition.dto.generated.DebtPositionDTO;
 import it.gov.pagopa.pu.organization.dto.generated.Broker;
 import it.gov.pagopa.pu.send.connector.debtpositions.service.DebtPositionService;
 import it.gov.pagopa.pu.send.connector.organization.service.BrokerService;
+import it.gov.pagopa.pu.send.connector.organization.service.OrganizationService;
 import it.gov.pagopa.pu.send.dto.DocumentDTO;
 import it.gov.pagopa.pu.send.dto.PuPayment;
 import it.gov.pagopa.pu.send.dto.PuRecipient;
@@ -14,6 +15,7 @@ import it.gov.pagopa.pu.send.dto.generated.Recipient;
 import it.gov.pagopa.pu.send.enums.FileStatus;
 import it.gov.pagopa.pu.send.enums.NotificationStatus;
 import it.gov.pagopa.pu.send.exception.UnknownDebtPositionException;
+import it.gov.pagopa.pu.send.util.DebtPositionUtils;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -26,10 +28,16 @@ public class CreateNotificationRequest2SendNotificationMapper {
 
   private final DebtPositionService debtPositionService;
   private final BrokerService brokerService;
+  private final OrganizationService organizationService;
 
-  public CreateNotificationRequest2SendNotificationMapper(DebtPositionService debtPositionService, BrokerService brokerService) {
+  public CreateNotificationRequest2SendNotificationMapper(
+    DebtPositionService debtPositionService,
+    BrokerService brokerService,
+    OrganizationService organizationService
+  ) {
     this.debtPositionService = debtPositionService;
     this.brokerService = brokerService;
+    this.organizationService = organizationService;
   }
 
   public SendNotification mapToModel(CreateNotificationRequest request, String accessToken) {
@@ -95,17 +103,29 @@ public class CreateNotificationRequest2SendNotificationMapper {
   private PuPayment getPuPayment(String accessToken, Long organizationId, Payment p) {
     if (p.getPagoPa() != null) {
       String nav = p.getPagoPa().getNoticeCode();
-      DebtPositionDTO debtPosition = debtPositionService.findDebtPositionByInstallment(organizationId, nav, accessToken);
-      if (debtPosition == null) {
-        throw new UnknownDebtPositionException("[DEBT_POSITION_NOT_FOUND] Cannot find debtPosition related to organizationId " + organizationId + " and having an Installment with NAV " + nav);
-      } else {
-        return new PuPayment(debtPosition.getDebtPositionId(), p, null);
+      String orgFiscalCode = p.getPagoPa().getCreditorTaxId();
+      if(isDebtPositionManagedByPU(orgFiscalCode, nav, accessToken)) {
+        DebtPositionDTO debtPosition = debtPositionService.findDebtPositionByInstallment(organizationId, nav, accessToken);
+        if (debtPosition == null) {
+          throw new UnknownDebtPositionException("[DEBT_POSITION_NOT_FOUND] Cannot find debtPosition related to organizationId " + organizationId + " and having an Installment with NAV " + nav);
+        } else {
+          return new PuPayment(debtPosition.getDebtPositionId(), p, null);
+        }
       }
+      return null;
     }
     if (p.getF24() != null) {
       return new PuPayment(null, p, null);
     }
     return null;
+  }
+
+  private boolean isDebtPositionManagedByPU(String orgFiscalCode, String nav, String accessToken) {
+    return organizationService.findByOrgFiscalCodeAndSegregationCode(
+      orgFiscalCode,
+      DebtPositionUtils.extractSegregationCodeFromNav(nav),
+      accessToken
+    ).isPresent();
   }
 
   private List<DocumentDTO> setDocuments(CreateNotificationRequest request) {

--- a/src/main/java/it/gov/pagopa/pu/send/mapper/SendNotification2NewNotificationRequestMapper.java
+++ b/src/main/java/it/gov/pagopa/pu/send/mapper/SendNotification2NewNotificationRequestMapper.java
@@ -97,7 +97,7 @@ public class SendNotification2NewNotificationRequestMapper {
 
         //payments domain to implements
         List<NotificationPaymentItemDTO> payments = getPayments(sendNotification, puRecipient);
-        notificationRecipient.setPayments(payments);
+        notificationRecipient.setPayments(payments.stream().filter(Objects::nonNull).toList());
         //end payments
 
         return notificationRecipient;
@@ -169,6 +169,7 @@ public class SendNotification2NewNotificationRequestMapper {
   private List<NotificationDocumentDTO> setDocuments(SendNotification sendNotification) {
     Set<String> attachmentFileNames = sendNotification.getPuRecipients().stream()
       .flatMap(r -> r.getPuPayments().stream())
+      .filter(Objects::nonNull)
       .flatMap(puPayment -> {
         Payment payment = puPayment.getPayment();
         return Stream.of(

--- a/src/main/java/it/gov/pagopa/pu/send/mapper/SendNotification2NewNotificationRequestMapper.java
+++ b/src/main/java/it/gov/pagopa/pu/send/mapper/SendNotification2NewNotificationRequestMapper.java
@@ -105,31 +105,33 @@ public class SendNotification2NewNotificationRequestMapper {
   }
 
   private static List<NotificationPaymentItemDTO> getPayments(SendNotification sendNotification, PuRecipient puRecipient) {
-    return puRecipient.getPuPayments().stream().map(puPayment -> {
-      PagoPaPaymentDTO pagoPa = null;
-      if (puPayment.getPayment().getPagoPa() != null) {
-        pagoPa = new PagoPaPaymentDTO();
-        pagoPa.setCreditorTaxId(puPayment.getPayment().getPagoPa().getCreditorTaxId());
-        pagoPa.setNoticeCode(puPayment.getPayment().getPagoPa().getNoticeCode());
-        pagoPa.setApplyCost(puPayment.getPayment().getPagoPa().getApplyCost());
+    return puRecipient.getPuPayments().stream()
+      .filter(Objects::nonNull)
+      .map(puPayment -> {
+        PagoPaPaymentDTO pagoPa = null;
+        if (puPayment.getPayment().getPagoPa() != null) {
+          pagoPa = new PagoPaPaymentDTO();
+          pagoPa.setCreditorTaxId(puPayment.getPayment().getPagoPa().getCreditorTaxId());
+          pagoPa.setNoticeCode(puPayment.getPayment().getPagoPa().getNoticeCode());
+          pagoPa.setApplyCost(puPayment.getPayment().getPagoPa().getApplyCost());
 
-        Optional<NotificationPaymentAttachmentDTO> attachment = getAttachment(sendNotification, puPayment);
-        attachment.ifPresent(pagoPa::setAttachment);
-      }
+          Optional<NotificationPaymentAttachmentDTO> attachment = getAttachment(sendNotification, puPayment);
+          attachment.ifPresent(pagoPa::setAttachment);
+        }
 
-      F24PaymentDTO f24Payment = null;
-      if (puPayment.getPayment().getF24() != null) {
-        f24Payment = new F24PaymentDTO();
-        f24Payment.setTitle(puPayment.getPayment().getF24().getTitle());
-        f24Payment.setApplyCost(puPayment.getPayment().getF24().getApplyCost());
-        Optional<NotificationMetadataAttachmentDTO> metadataAttachment = getMetadataAttachment(sendNotification, puPayment);
-        metadataAttachment.ifPresent(f24Payment::setMetadataAttachment);
-      }
+        F24PaymentDTO f24Payment = null;
+        if (puPayment.getPayment().getF24() != null) {
+          f24Payment = new F24PaymentDTO();
+          f24Payment.setTitle(puPayment.getPayment().getF24().getTitle());
+          f24Payment.setApplyCost(puPayment.getPayment().getF24().getApplyCost());
+          Optional<NotificationMetadataAttachmentDTO> metadataAttachment = getMetadataAttachment(sendNotification, puPayment);
+          metadataAttachment.ifPresent(f24Payment::setMetadataAttachment);
+        }
 
-      return new NotificationPaymentItemDTO()
-        .pagoPa(pagoPa)
-        .f24(f24Payment);
-    }).toList();
+        return new NotificationPaymentItemDTO()
+          .pagoPa(pagoPa)
+          .f24(f24Payment);
+      }).toList();
   }
 
   private static Optional<NotificationPaymentAttachmentDTO> getAttachment(SendNotification sendNotification, PuPayment puPayment) {

--- a/src/main/java/it/gov/pagopa/pu/send/mapper/SendNotification2SendNotificationDTOMapper.java
+++ b/src/main/java/it/gov/pagopa/pu/send/mapper/SendNotification2SendNotificationDTOMapper.java
@@ -29,11 +29,11 @@ public class SendNotification2SendNotificationDTOMapper {
   private static List<SendNotificationPaymentsDTO> buildPayments(SendNotificationNoPII sendNotificationNoPII) {
     return sendNotificationNoPII.getRecipients().stream()
       .flatMap(recipient -> recipient.getPuPayments().stream())
-      .filter(p -> p != null && p.getDebtPositionId() != null)
-      .collect(Collectors.groupingBy(PuPayment::getDebtPositionId))
+      .filter(Objects::nonNull)
+      .collect(Collectors.groupingBy(p -> Optional.ofNullable(p.getDebtPositionId())))
       .entrySet().stream()
       .map(entry -> new SendNotificationPaymentsDTO(
-        entry.getKey(),
+        entry.getKey().orElse(null),
         entry.getValue().stream()
           .map(p -> Optional.ofNullable(p.getPayment())
             .map(Payment::getPagoPa)

--- a/src/main/java/it/gov/pagopa/pu/send/mapper/SendNotification2SendNotificationDTOMapper.java
+++ b/src/main/java/it/gov/pagopa/pu/send/mapper/SendNotification2SendNotificationDTOMapper.java
@@ -29,7 +29,7 @@ public class SendNotification2SendNotificationDTOMapper {
   private static List<SendNotificationPaymentsDTO> buildPayments(SendNotificationNoPII sendNotificationNoPII) {
     return sendNotificationNoPII.getRecipients().stream()
       .flatMap(recipient -> recipient.getPuPayments().stream())
-      .filter(p -> p.getDebtPositionId() != null)
+      .filter(p -> p != null && p.getDebtPositionId() != null)
       .collect(Collectors.groupingBy(PuPayment::getDebtPositionId))
       .entrySet().stream()
       .map(entry -> new SendNotificationPaymentsDTO(

--- a/src/main/java/it/gov/pagopa/pu/send/service/SendFacadeServiceImpl.java
+++ b/src/main/java/it/gov/pagopa/pu/send/service/SendFacadeServiceImpl.java
@@ -279,11 +279,6 @@ public class SendFacadeServiceImpl implements SendFacadeService {
   private LegalFactDownloadMetadataDTO retrieveLegalFactDownloadMetadata(SendNotificationDTO sendNotification,
                                                                          String legalFactId,
                                                                         String accessToken) {
-    // Validate status
-    if(!NotificationStatus.ACCEPTED.equals(sendNotification.getStatus())) {
-      throw new InvalidStatusException(NotificationStatus.ACCEPTED, sendNotification.getStatus());
-    }
-
     LegalFactDownloadMetadataResponseDTO legalFactDownloadMetadata = sendService.getLegalFactDownloadMetadata(
       sendNotification.getIun(),
       legalFactId,

--- a/src/main/java/it/gov/pagopa/pu/send/util/DebtPositionUtils.java
+++ b/src/main/java/it/gov/pagopa/pu/send/util/DebtPositionUtils.java
@@ -1,0 +1,11 @@
+package it.gov.pagopa.pu.send.util;
+
+public class DebtPositionUtils {
+
+  private DebtPositionUtils(){}
+
+  public static String extractSegregationCodeFromNav(String nav) {
+    return nav.substring(1,3); //ex. nav: "345670000000000199" -> segregationCode: "45"
+  }
+
+}

--- a/src/test/java/it/gov/pagopa/pu/send/connector/organization/client/OrganizationApiClientTest.java
+++ b/src/test/java/it/gov/pagopa/pu/send/connector/organization/client/OrganizationApiClientTest.java
@@ -2,6 +2,7 @@ package it.gov.pagopa.pu.send.connector.organization.client;
 
 import it.gov.pagopa.pu.organization.client.generated.OrganizationApi;
 import it.gov.pagopa.pu.organization.client.generated.OrganizationEntityControllerApi;
+import it.gov.pagopa.pu.organization.client.generated.OrganizationSearchControllerApi;
 import it.gov.pagopa.pu.organization.dto.generated.Organization;
 import it.gov.pagopa.pu.organization.dto.generated.OrganizationApiKeyType;
 import it.gov.pagopa.pu.send.connector.organization.config.OrganizationApisHolder;
@@ -15,6 +16,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.client.HttpClientErrorException;
 
+import java.util.Optional;
+
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
@@ -27,6 +30,8 @@ class OrganizationApiClientTest {
   private OrganizationApi organizationApiMock;
   @Mock
   private OrganizationEntityControllerApi organizationEntityControllerApiMock;
+  @Mock
+  private OrganizationSearchControllerApi organizationSearchControllerApiMock;
 
   private OrganizationApiClient organizationApiClient;
 
@@ -108,5 +113,44 @@ class OrganizationApiClientTest {
 
     // Then
     Assertions.assertNull(result);
+  }
+
+  @Test
+  void whenFindByOrgFiscalCodeAndSegregationCodeThenInvokeWithAccessToken() {
+    // Given
+    String accessToken = "ACCESSTOKEN";
+    String orgFiscalCode = "00002";
+    String segregationCode = "01";
+    Organization expectedResult = new Organization();
+
+    Mockito.when(apisHolder.getOrganizationSearchControllerApi(accessToken))
+      .thenReturn(organizationSearchControllerApiMock);
+    Mockito.when(organizationSearchControllerApiMock.crudOrganizationsFindByOrgFiscalCodeAndSegregationCode(orgFiscalCode, segregationCode))
+      .thenReturn(expectedResult);
+
+    // When
+    Optional<Organization> result = organizationApiClient.findByOrgFiscalCodeAndSegregationCode(orgFiscalCode, segregationCode, accessToken);
+
+    // Then
+    Assertions.assertTrue(result.isPresent());
+    Assertions.assertEquals(expectedResult, result.get());
+  }
+
+  @Test
+  void givenNotExistentOrganizationIdWhenFindByOrgFiscalCodeAndSegregationCodeThenEmpty() {
+    String accessToken = "ACCESSTOKEN";
+    String orgFiscalCode = "00002";
+    String segregationCode = "01";
+
+    Mockito.when(apisHolder.getOrganizationSearchControllerApi(accessToken))
+      .thenReturn(organizationSearchControllerApiMock);
+    Mockito.when(organizationSearchControllerApiMock.crudOrganizationsFindByOrgFiscalCodeAndSegregationCode(orgFiscalCode, segregationCode))
+      .thenThrow(HttpClientErrorException.create(HttpStatus.NOT_FOUND, "NotFound", null, null, null));
+
+    // When
+    Optional<Organization> result = organizationApiClient.findByOrgFiscalCodeAndSegregationCode(orgFiscalCode, segregationCode, accessToken);
+
+    // Then
+    Assertions.assertTrue(result.isEmpty());
   }
 }

--- a/src/test/java/it/gov/pagopa/pu/send/connector/organization/config/OrganizationApisHolderTest.java
+++ b/src/test/java/it/gov/pagopa/pu/send/connector/organization/config/OrganizationApisHolderTest.java
@@ -63,4 +63,14 @@ class OrganizationApisHolderTest extends BaseApiHolderTest {
       new ParameterizedTypeReference<>() {},
       apisHolder::unload);
   }
+
+  @Test
+  void whenGetOrganizationSearchControllerApiThenAuthenticationShouldBeSetInThreadSafeMode() throws InterruptedException {
+    assertAuthenticationShouldBeSetInThreadSafeMode(
+      token -> apisHolder.getOrganizationSearchControllerApi(token)
+        .crudOrganizationsFindByOrgFiscalCodeAndSegregationCode("orgFiscalCode", "segregationCode"),
+      new ParameterizedTypeReference<>() {},
+      apisHolder::unload);
+  }
+
 }

--- a/src/test/java/it/gov/pagopa/pu/send/connector/organization/service/OrganizationServiceTest.java
+++ b/src/test/java/it/gov/pagopa/pu/send/connector/organization/service/OrganizationServiceTest.java
@@ -11,6 +11,8 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Optional;
+
 @ExtendWith(MockitoExtension.class)
 class OrganizationServiceTest {
 
@@ -62,4 +64,24 @@ class OrganizationServiceTest {
     // Then
     Assertions.assertSame(organization, result);
   }
+
+  @Test
+  void whenFindByOrgFiscalCodeAndSegregationCodeThenInvokeClient(){
+    // Given
+    String orgFiscalCode = "orgFiscalCode";
+    String segregationCode = "segregationCode";
+    String accessToken = "accessToken";
+    Organization organization = new Organization();
+
+    Mockito.when(organizationApiClientMock.findByOrgFiscalCodeAndSegregationCode(orgFiscalCode, segregationCode, accessToken))
+      .thenReturn(Optional.of(organization));
+
+    // When
+    Optional<Organization> result = service.findByOrgFiscalCodeAndSegregationCode(orgFiscalCode, segregationCode, accessToken);
+
+    // Then
+    Assertions.assertTrue(result.isPresent());
+    Assertions.assertSame(organization, result.get());
+  }
+
 }

--- a/src/test/java/it/gov/pagopa/pu/send/mapper/CreateNotificationRequest2SendNotificationPIIMapperTest.java
+++ b/src/test/java/it/gov/pagopa/pu/send/mapper/CreateNotificationRequest2SendNotificationPIIMapperTest.java
@@ -141,6 +141,9 @@ class CreateNotificationRequest2SendNotificationPIIMapperTest {
       .getPayments().getFirst().getPagoPa().getCreditorTaxId();
     String segregationCode = DebtPositionUtils.extractSegregationCodeFromNav(nav);
 
+    DebtPositionDTO debtPosition = new DebtPositionDTO();
+    debtPosition.setDebtPositionId(null);
+
     Mockito.when(organizationServiceMock.findByOrgFiscalCodeAndSegregationCode(orgFiscalCode, segregationCode, accessToken))
       .thenReturn(Optional.empty());
 
@@ -153,7 +156,7 @@ class CreateNotificationRequest2SendNotificationPIIMapperTest {
     Assertions.assertNotNull(result);
     Assertions.assertEquals(RecipientTypeEnum.PF, result.getPuRecipients().getFirst().getRecipient().getRecipientType());
     Assertions.assertEquals("ROSSI MARIO", result.getPuRecipients().getFirst().getRecipient().getDenomination());
-    Assertions.assertNull(result.getPuRecipients().getFirst().getPuPayments().getFirst());
+    checkPayments(debtPosition, result);
     checkDocuments(result);
     Assertions.assertEquals(NotificationFeePolicyEnum.DELIVERY_MODE.getValue(), result.getNotificationFeePolicy());
     Assertions.assertEquals(PhysicalCommunicationTypeEnum.AR_REGISTERED_LETTER.getValue(), result.getPhysicalCommunicationType());

--- a/src/test/java/it/gov/pagopa/pu/send/mapper/CreateNotificationRequest2SendNotificationPIIMapperTest.java
+++ b/src/test/java/it/gov/pagopa/pu/send/mapper/CreateNotificationRequest2SendNotificationPIIMapperTest.java
@@ -2,9 +2,11 @@ package it.gov.pagopa.pu.send.mapper;
 
 import it.gov.pagopa.pu.debtposition.dto.generated.DebtPositionDTO;
 import it.gov.pagopa.pu.organization.dto.generated.Broker;
+import it.gov.pagopa.pu.organization.dto.generated.Organization;
 import it.gov.pagopa.pu.organization.dto.generated.PagoPaInteractionModel;
 import it.gov.pagopa.pu.send.connector.debtpositions.service.DebtPositionService;
 import it.gov.pagopa.pu.send.connector.organization.service.BrokerService;
+import it.gov.pagopa.pu.send.connector.organization.service.OrganizationService;
 import it.gov.pagopa.pu.send.dto.SendNotification;
 import it.gov.pagopa.pu.send.dto.generated.CreateNotificationRequest;
 import it.gov.pagopa.pu.send.dto.generated.CreateNotificationRequest.NotificationFeePolicyEnum;
@@ -15,6 +17,7 @@ import it.gov.pagopa.pu.send.dto.generated.Recipient.RecipientTypeEnum;
 import it.gov.pagopa.pu.send.enums.FileStatus;
 import it.gov.pagopa.pu.send.enums.NotificationStatus;
 import it.gov.pagopa.pu.send.exception.UnknownDebtPositionException;
+import it.gov.pagopa.pu.send.util.DebtPositionUtils;
 import it.gov.pagopa.pu.send.util.TestUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -31,6 +34,7 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Optional;
 
 import static it.gov.pagopa.pu.send.util.faker.DocumentFaker.buildDocument;
 import static it.gov.pagopa.pu.send.util.faker.RecipientFaker.buildRecipient;
@@ -42,17 +46,27 @@ class CreateNotificationRequest2SendNotificationPIIMapperTest {
   private DebtPositionService debtPositionServiceMock;
   @Mock
   private BrokerService brokerServiceMock;
+  @Mock
+  private OrganizationService organizationServiceMock;
 
   private CreateNotificationRequest2SendNotificationMapper mapper;
 
   @BeforeEach
   void init() {
-    mapper = new CreateNotificationRequest2SendNotificationMapper(debtPositionServiceMock, brokerServiceMock);
+    mapper = new CreateNotificationRequest2SendNotificationMapper(
+      debtPositionServiceMock,
+      brokerServiceMock,
+      organizationServiceMock
+    );
   }
 
   @AfterEach
   void verifyNoMoreInteractions() {
-    Mockito.verifyNoMoreInteractions(debtPositionServiceMock, brokerServiceMock);
+    Mockito.verifyNoMoreInteractions(
+      debtPositionServiceMock,
+      brokerServiceMock,
+      organizationServiceMock
+    );
   }
 
   @Test
@@ -71,12 +85,18 @@ class CreateNotificationRequest2SendNotificationPIIMapperTest {
 
     String nav = request.getRecipients().getFirst()
       .getPayments().getFirst().getPagoPa().getNoticeCode();
+    String orgFiscalCode = request.getRecipients().getFirst()
+      .getPayments().getFirst().getPagoPa().getCreditorTaxId();
+    String segregationCode = DebtPositionUtils.extractSegregationCodeFromNav(nav);
 
     DebtPositionDTO debtPosition = new DebtPositionDTO();
     debtPosition.setDebtPositionId(3L);
 
     Mockito.when(debtPositionServiceMock.findDebtPositionByInstallment(request.getOrganizationId(), nav, accessToken))
       .thenReturn(debtPosition);
+
+    Mockito.when(organizationServiceMock.findByOrgFiscalCodeAndSegregationCode(orgFiscalCode, segregationCode, accessToken))
+      .thenReturn(Optional.of(new Organization()));
 
     // When
     SendNotification result = mapper.mapToModel(request, accessToken);
@@ -99,6 +119,54 @@ class CreateNotificationRequest2SendNotificationPIIMapperTest {
     Assertions.assertEquals(22, result.getVat());
     Assertions.assertEquals(LocalDate.now().toString(), result.getPaymentExpirationDate());
     Assertions.assertEquals("SYNC", result.getPagoPaIntMode());
+  }
+
+  @Test
+  void givenCreateNotificationRequestWithPaymentOutsidePUWhenMapToModelThenOk() {
+    // Given
+    CreateNotificationRequest request = buildRequest();
+    String accessToken = "ACCESSTOKEN";
+
+    Broker broker = Mockito.mock(Broker.class);
+
+    Mockito.when(broker.getPagoPaInteractionModel())
+      .thenReturn(PagoPaInteractionModel.SYNC);
+
+    Mockito.when(brokerServiceMock.getBrokerByOrganizationId(request.getOrganizationId(), accessToken))
+      .thenReturn(broker);
+
+    String nav = request.getRecipients().getFirst()
+      .getPayments().getFirst().getPagoPa().getNoticeCode();
+    String orgFiscalCode = request.getRecipients().getFirst()
+      .getPayments().getFirst().getPagoPa().getCreditorTaxId();
+    String segregationCode = DebtPositionUtils.extractSegregationCodeFromNav(nav);
+
+    Mockito.when(organizationServiceMock.findByOrgFiscalCodeAndSegregationCode(orgFiscalCode, segregationCode, accessToken))
+      .thenReturn(Optional.empty());
+
+    // When
+    SendNotification result = mapper.mapToModel(request, accessToken);
+
+    // Then
+    TestUtils.checkNotNullFields(result, "sendNotificationId", "organizationId", "notificationRequestId", "iun", "notificationDate", "personalDataId", "noPII", "legalFacts");
+
+    Assertions.assertNotNull(result);
+    Assertions.assertEquals(RecipientTypeEnum.PF, result.getPuRecipients().getFirst().getRecipient().getRecipientType());
+    Assertions.assertEquals("ROSSI MARIO", result.getPuRecipients().getFirst().getRecipient().getDenomination());
+    Assertions.assertNull(result.getPuRecipients().getFirst().getPuPayments().getFirst());
+    checkDocuments(result);
+    Assertions.assertEquals(NotificationFeePolicyEnum.DELIVERY_MODE.getValue(), result.getNotificationFeePolicy());
+    Assertions.assertEquals(PhysicalCommunicationTypeEnum.AR_REGISTERED_LETTER.getValue(), result.getPhysicalCommunicationType());
+    Assertions.assertEquals("SENDERDENOMINATION", result.getSenderDenomination());
+    Assertions.assertEquals("TAXID", result.getSenderTaxId());
+    Assertions.assertEquals(99999999, result.getAmount());
+    Assertions.assertEquals("TAXONOMYCODE", result.getTaxonomyCode());
+    Assertions.assertEquals(100, result.getPaFee());
+    Assertions.assertEquals(22, result.getVat());
+    Assertions.assertEquals(LocalDate.now().toString(), result.getPaymentExpirationDate());
+    Assertions.assertEquals("SYNC", result.getPagoPaIntMode());
+
+    Mockito.verifyNoInteractions(debtPositionServiceMock);
   }
 
   @ParameterizedTest
@@ -137,8 +205,14 @@ class CreateNotificationRequest2SendNotificationPIIMapperTest {
 
     if (paymentNull.equals("f24null")) {
       String nav = request.getRecipients().getFirst().getPayments().getFirst().getPagoPa().getNoticeCode();
+      String orgFiscalCode = request.getRecipients().getFirst()
+        .getPayments().getFirst().getPagoPa().getCreditorTaxId();
+      String segregationCode = DebtPositionUtils.extractSegregationCodeFromNav(nav);
+
       Mockito.when(debtPositionServiceMock.findDebtPositionByInstallment(request.getOrganizationId(), nav, accessToken))
         .thenReturn(debtPosition);
+      Mockito.when(organizationServiceMock.findByOrgFiscalCodeAndSegregationCode(orgFiscalCode, segregationCode, accessToken))
+        .thenReturn(Optional.of(new Organization()));
     }
 
     // When
@@ -169,9 +243,14 @@ class CreateNotificationRequest2SendNotificationPIIMapperTest {
     String accessToken = "ACCESSTOKEN";
     CreateNotificationRequest request = buildRequest();
     String nav = request.getRecipients().getFirst().getPayments().getFirst().getPagoPa().getNoticeCode();
+    String orgFiscalCode = request.getRecipients().getFirst()
+      .getPayments().getFirst().getPagoPa().getCreditorTaxId();
+    String segregationCode = DebtPositionUtils.extractSegregationCodeFromNav(nav);
 
     Mockito.when(debtPositionServiceMock.findDebtPositionByInstallment(request.getOrganizationId(), nav, accessToken))
       .thenReturn(null);
+    Mockito.when(organizationServiceMock.findByOrgFiscalCodeAndSegregationCode(orgFiscalCode, segregationCode, accessToken))
+      .thenReturn(Optional.of(new Organization()));
 
     Assertions.assertThrows(UnknownDebtPositionException.class, () -> mapper.mapToModel(request, accessToken));
   }

--- a/src/test/java/it/gov/pagopa/pu/send/mapper/CreateNotificationRequest2SendNotificationPIIMapperTest.java
+++ b/src/test/java/it/gov/pagopa/pu/send/mapper/CreateNotificationRequest2SendNotificationPIIMapperTest.java
@@ -91,12 +91,14 @@ class CreateNotificationRequest2SendNotificationPIIMapperTest {
 
     DebtPositionDTO debtPosition = new DebtPositionDTO();
     debtPosition.setDebtPositionId(3L);
+    Organization organization = new Organization();
+    organization.setOrganizationId(request.getOrganizationId());
 
-    Mockito.when(debtPositionServiceMock.findDebtPositionByInstallment(request.getOrganizationId(), nav, accessToken))
+    Mockito.when(debtPositionServiceMock.findDebtPositionByInstallment(organization.getOrganizationId(), nav, accessToken))
       .thenReturn(debtPosition);
 
     Mockito.when(organizationServiceMock.findByOrgFiscalCodeAndSegregationCode(orgFiscalCode, segregationCode, accessToken))
-      .thenReturn(Optional.of(new Organization()));
+      .thenReturn(Optional.of(organization));
 
     // When
     SendNotification result = mapper.mapToModel(request, accessToken);
@@ -112,7 +114,7 @@ class CreateNotificationRequest2SendNotificationPIIMapperTest {
     Assertions.assertEquals(NotificationFeePolicyEnum.DELIVERY_MODE.getValue(), result.getNotificationFeePolicy());
     Assertions.assertEquals(PhysicalCommunicationTypeEnum.AR_REGISTERED_LETTER.getValue(), result.getPhysicalCommunicationType());
     Assertions.assertEquals("SENDERDENOMINATION", result.getSenderDenomination());
-    Assertions.assertEquals("TAXID", result.getSenderTaxId());
+    Assertions.assertEquals("SENDERTAXID", result.getSenderTaxId());
     Assertions.assertEquals(99999999, result.getAmount());
     Assertions.assertEquals("TAXONOMYCODE", result.getTaxonomyCode());
     Assertions.assertEquals(100, result.getPaFee());
@@ -161,7 +163,7 @@ class CreateNotificationRequest2SendNotificationPIIMapperTest {
     Assertions.assertEquals(NotificationFeePolicyEnum.DELIVERY_MODE.getValue(), result.getNotificationFeePolicy());
     Assertions.assertEquals(PhysicalCommunicationTypeEnum.AR_REGISTERED_LETTER.getValue(), result.getPhysicalCommunicationType());
     Assertions.assertEquals("SENDERDENOMINATION", result.getSenderDenomination());
-    Assertions.assertEquals("TAXID", result.getSenderTaxId());
+    Assertions.assertEquals("SENDERTAXID", result.getSenderTaxId());
     Assertions.assertEquals(99999999, result.getAmount());
     Assertions.assertEquals("TAXONOMYCODE", result.getTaxonomyCode());
     Assertions.assertEquals(100, result.getPaFee());
@@ -205,6 +207,8 @@ class CreateNotificationRequest2SendNotificationPIIMapperTest {
 
     DebtPositionDTO debtPosition = new DebtPositionDTO();
     debtPosition.setDebtPositionId(3L);
+    Organization organization = new Organization();
+    organization.setOrganizationId(request.getOrganizationId());
 
     if (paymentNull.equals("f24null")) {
       String nav = request.getRecipients().getFirst().getPayments().getFirst().getPagoPa().getNoticeCode();
@@ -212,10 +216,10 @@ class CreateNotificationRequest2SendNotificationPIIMapperTest {
         .getPayments().getFirst().getPagoPa().getCreditorTaxId();
       String segregationCode = DebtPositionUtils.extractSegregationCodeFromNav(nav);
 
-      Mockito.when(debtPositionServiceMock.findDebtPositionByInstallment(request.getOrganizationId(), nav, accessToken))
+      Mockito.when(debtPositionServiceMock.findDebtPositionByInstallment(organization.getOrganizationId(), nav, accessToken))
         .thenReturn(debtPosition);
       Mockito.when(organizationServiceMock.findByOrgFiscalCodeAndSegregationCode(orgFiscalCode, segregationCode, accessToken))
-        .thenReturn(Optional.of(new Organization()));
+        .thenReturn(Optional.of(organization));
     }
 
     // When
@@ -236,7 +240,7 @@ class CreateNotificationRequest2SendNotificationPIIMapperTest {
     Assertions.assertEquals(NotificationFeePolicyEnum.DELIVERY_MODE.getValue(), result.getNotificationFeePolicy());
     Assertions.assertEquals(PhysicalCommunicationTypeEnum.AR_REGISTERED_LETTER.getValue(), result.getPhysicalCommunicationType());
     Assertions.assertEquals("SENDERDENOMINATION", result.getSenderDenomination());
-    Assertions.assertEquals("TAXID", result.getSenderTaxId());
+    Assertions.assertEquals("SENDERTAXID", result.getSenderTaxId());
     Assertions.assertEquals("TAXONOMYCODE", result.getTaxonomyCode());
     Assertions.assertEquals("ASYNC", result.getPagoPaIntMode());
   }
@@ -250,10 +254,13 @@ class CreateNotificationRequest2SendNotificationPIIMapperTest {
       .getPayments().getFirst().getPagoPa().getCreditorTaxId();
     String segregationCode = DebtPositionUtils.extractSegregationCodeFromNav(nav);
 
-    Mockito.when(debtPositionServiceMock.findDebtPositionByInstallment(request.getOrganizationId(), nav, accessToken))
+    Organization organization = new Organization();
+    organization.setOrganizationId(request.getOrganizationId());
+
+    Mockito.when(debtPositionServiceMock.findDebtPositionByInstallment(organization.getOrganizationId(), nav, accessToken))
       .thenReturn(null);
     Mockito.when(organizationServiceMock.findByOrgFiscalCodeAndSegregationCode(orgFiscalCode, segregationCode, accessToken))
-      .thenReturn(Optional.of(new Organization()));
+      .thenReturn(Optional.of(organization));
 
     Assertions.assertThrows(UnknownDebtPositionException.class, () -> mapper.mapToModel(request, accessToken));
   }
@@ -270,7 +277,7 @@ class CreateNotificationRequest2SendNotificationPIIMapperTest {
     request.setNotificationFeePolicy(NotificationFeePolicyEnum.DELIVERY_MODE);
     request.setPhysicalCommunicationType(PhysicalCommunicationTypeEnum.AR_REGISTERED_LETTER);
     request.setSenderDenomination("SENDERDENOMINATION");
-    request.setSenderTaxId("TAXID");
+    request.setSenderTaxId("SENDERTAXID");
     request.setAmount(BigDecimal.valueOf(99999999));
     request.setTaxonomyCode("TAXONOMYCODE");
     request.setPaFee(100);

--- a/src/test/java/it/gov/pagopa/pu/send/mapper/SendNotification2SendNotificationDTOMapperTest.java
+++ b/src/test/java/it/gov/pagopa/pu/send/mapper/SendNotification2SendNotificationDTOMapperTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.OffsetDateTime;
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -24,26 +24,12 @@ class SendNotification2SendNotificationDTOMapperTest {
   private final SendNotification2SendNotificationDTOMapper mapper = new SendNotification2SendNotificationDTOMapper();
 
   @Test
-  void givenSendNotificationWhenMapThenReturnSendNotificationDTO() {
+  void givenPagoPaPaymentSendNotificationWhenMapThenReturnSendNotificationDTO() {
     OffsetDateTime now = OffsetDateTime.now();
-    PuPayment payment1 = new PuPayment(3L, new Payment(PagoPa.builder().noticeCode("NOTICECODE1").build(), F24Payment.builder().title("F24").build()), now);
-    PuPayment payment2 = new PuPayment(null, new Payment(null, F24Payment.builder().title("F24").build()), null);
-    PuPayment payment3 = new PuPayment(4L, new Payment(PagoPa.builder().noticeCode("NOTICECODE3").build(), F24Payment.builder().title("F24").build()), now);
-
-    PuRecipientNoPIIDTO recipient = new PuRecipientNoPIIDTO();
-    List<PuPayment> puPaymentList = new ArrayList<>();
-    puPaymentList.add(payment1);
-    puPaymentList.add(payment2);
-    puPaymentList.add(payment3);
-    puPaymentList.add(null);
-    recipient.setPuPayments(puPaymentList);
-
-    SendNotificationNoPII sendNotificationNoPII = new SendNotificationNoPII();
-    sendNotificationNoPII.setSendNotificationId("12345");
-    sendNotificationNoPII.setOrganizationId(1L);
-    sendNotificationNoPII.setIun("IUN");
-    sendNotificationNoPII.setStatus(NotificationStatus.IN_VALIDATION);
-    sendNotificationNoPII.setRecipients(List.of(recipient));
+    PuPayment puPayment1 = new PuPayment(1L, new Payment(PagoPa.builder().noticeCode("NOTICECODE1").build(), null), now);
+    PuPayment puPayment2 = new PuPayment(1L, new Payment(PagoPa.builder().noticeCode("NOTICECODE2").build(), null), now);
+    PuPayment puPayment3 = new PuPayment(2L, new Payment(PagoPa.builder().noticeCode("NOTICECODE3").build(), null), now);
+    SendNotificationNoPII sendNotificationNoPII = createSendNotificationNoPII(List.of(puPayment1, puPayment2, puPayment3));
 
     // when
     SendNotificationDTO result = mapper.apply(sendNotificationNoPII);
@@ -57,9 +43,97 @@ class SendNotification2SendNotificationDTOMapperTest {
     assertEquals(NotificationStatus.IN_VALIDATION, result.getStatus());
 
     List<SendNotificationPaymentsDTO> expectedPayments = List.of(
-      new SendNotificationPaymentsDTO(3L, List.of("NOTICECODE1"), now),
-      new SendNotificationPaymentsDTO(4L, List.of("NOTICECODE3"), now)
+      new SendNotificationPaymentsDTO(1L, List.of("NOTICECODE1", "NOTICECODE2"), now),
+      new SendNotificationPaymentsDTO(2L, List.of("NOTICECODE3"), now)
     );
     assertEquals(expectedPayments, result.getPayments());
   }
+
+  @Test
+  void givenF24PaymentSendNotificationWhenMapThenReturnSendNotificationDTO() {
+    OffsetDateTime now = OffsetDateTime.now();
+    PuPayment puPayment = new PuPayment(1L, new Payment(null,  F24Payment.builder().title("F24").build()), now);
+    SendNotificationNoPII sendNotificationNoPII = createSendNotificationNoPII(List.of(puPayment));
+
+    // when
+    SendNotificationDTO result = mapper.apply(sendNotificationNoPII);
+
+    // then
+    TestUtils.checkNotNullFields(result);
+    assertNotNull(result);
+    assertEquals("12345", result.getSendNotificationId());
+    assertEquals(1L, result.getOrganizationId());
+    assertEquals("IUN", result.getIun());
+    assertEquals(NotificationStatus.IN_VALIDATION, result.getStatus());
+
+    List<SendNotificationPaymentsDTO> expectedPayments = List.of(
+      new SendNotificationPaymentsDTO(1L, Collections.emptyList(), now)
+    );
+    assertEquals(expectedPayments, result.getPayments());
+  }
+
+  @Test
+  void givenBothPagoPaAndF24PaymentSendNotificationWhenMapThenReturnSendNotificationDTO() {
+    OffsetDateTime now = OffsetDateTime.now();
+    Payment payment = new Payment(
+      PagoPa.builder().noticeCode("NOTICECODE").build(),
+      F24Payment.builder().title("F24").build()
+    );
+    PuPayment puPayment = new PuPayment(1L, payment, now);
+    SendNotificationNoPII sendNotificationNoPII = createSendNotificationNoPII(List.of(puPayment));
+
+    // when
+    SendNotificationDTO result = mapper.apply(sendNotificationNoPII);
+
+    // then
+    TestUtils.checkNotNullFields(result);
+    assertNotNull(result);
+    assertEquals("12345", result.getSendNotificationId());
+    assertEquals(1L, result.getOrganizationId());
+    assertEquals("IUN", result.getIun());
+    assertEquals(NotificationStatus.IN_VALIDATION, result.getStatus());
+
+    List<SendNotificationPaymentsDTO> expectedPayments = List.of(
+      new SendNotificationPaymentsDTO(1L, List.of("NOTICECODE"), now)
+    );
+    assertEquals(expectedPayments, result.getPayments());
+  }
+
+  @Test
+  void givenPagoPaPaymentWithoutDebtPositionIdSendNotificationWhenMapThenReturnSendNotificationDTO() {
+    OffsetDateTime now = OffsetDateTime.now();
+    PuPayment puPayment = new PuPayment(null, new Payment(PagoPa.builder().noticeCode("NOTICECODE").build(), null), now);
+    SendNotificationNoPII sendNotificationNoPII = createSendNotificationNoPII(List.of(puPayment));
+
+    // when
+    SendNotificationDTO result = mapper.apply(sendNotificationNoPII);
+
+    // then
+    TestUtils.checkNotNullFields(result);
+    assertNotNull(result);
+    assertEquals("12345", result.getSendNotificationId());
+    assertEquals(1L, result.getOrganizationId());
+    assertEquals("IUN", result.getIun());
+    assertEquals(NotificationStatus.IN_VALIDATION, result.getStatus());
+
+    List<SendNotificationPaymentsDTO> expectedPayments = List.of(
+      new SendNotificationPaymentsDTO(null, List.of("NOTICECODE"), now)
+    );
+    assertEquals(expectedPayments, result.getPayments());
+  }
+
+
+  private static SendNotificationNoPII createSendNotificationNoPII(List<PuPayment> puPayments) {
+    PuRecipientNoPIIDTO recipient = new PuRecipientNoPIIDTO();
+    recipient.setPuPayments(puPayments);
+
+    SendNotificationNoPII sendNotificationNoPII = new SendNotificationNoPII();
+    sendNotificationNoPII.setSendNotificationId("12345");
+    sendNotificationNoPII.setOrganizationId(1L);
+    sendNotificationNoPII.setIun("IUN");
+    sendNotificationNoPII.setStatus(NotificationStatus.IN_VALIDATION);
+    sendNotificationNoPII.setRecipients(List.of(recipient));
+    return sendNotificationNoPII;
+  }
+
 }

--- a/src/test/java/it/gov/pagopa/pu/send/mapper/SendNotification2SendNotificationDTOMapperTest.java
+++ b/src/test/java/it/gov/pagopa/pu/send/mapper/SendNotification2SendNotificationDTOMapperTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.OffsetDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -30,7 +31,12 @@ class SendNotification2SendNotificationDTOMapperTest {
     PuPayment payment3 = new PuPayment(4L, new Payment(PagoPa.builder().noticeCode("NOTICECODE3").build(), F24Payment.builder().title("F24").build()), now);
 
     PuRecipientNoPIIDTO recipient = new PuRecipientNoPIIDTO();
-    recipient.setPuPayments(List.of(payment1, payment2, payment3));
+    List<PuPayment> puPaymentList = new ArrayList<>();
+    puPaymentList.add(payment1);
+    puPaymentList.add(payment2);
+    puPaymentList.add(payment3);
+    puPaymentList.add(null);
+    recipient.setPuPayments(puPaymentList);
 
     SendNotificationNoPII sendNotificationNoPII = new SendNotificationNoPII();
     sendNotificationNoPII.setSendNotificationId("12345");

--- a/src/test/java/it/gov/pagopa/pu/send/service/SendFacadeServiceImplTest.java
+++ b/src/test/java/it/gov/pagopa/pu/send/service/SendFacadeServiceImplTest.java
@@ -1056,40 +1056,6 @@ class SendFacadeServiceImplTest {
   }
 
   @Test
-  void givenNotAcceptedNotificationWhenRetrieveLegalFactDownloadMetadataThenThrowInvalidStatusException() {
-    // GIVEN
-    String accessToken = "ACCESS_TOKEN";
-    String sendNotificationId = "SEND_NOTIFICATION_ID";
-    String legalFactId = "LEGAL_FACT_ID";
-    String iun = "1234";
-
-    SendNotificationNoPII notification = SendNotificationNoPII.builder()
-      .sendNotificationId(sendNotificationId)
-      .iun(iun)
-      .status(NotificationStatus.IN_VALIDATION)
-      .build();
-    SendNotificationDTO notificationDTO = SendNotificationDTO.builder()
-      .sendNotificationId(sendNotificationId)
-      .iun(iun)
-      .status(NotificationStatus.IN_VALIDATION)
-      .build();
-
-    Mockito.when(sendNotificationNoPIIRepositoryMock.findById(sendNotificationId))
-      .thenReturn(Optional.of(notification));
-
-    Mockito.when(sendNotificationDTOMapperMock.apply(notification))
-      .thenReturn(notificationDTO);
-
-    // WHEN
-    InvalidStatusException exception = assertThrows(InvalidStatusException.class, () ->
-      sendService.retrieveLegalFactDownloadMetadata(sendNotificationId, legalFactId, accessToken)
-    );
-
-    // THEN
-    assertEquals("[INVALID_NOTIFICATION_STATUS] Notification status error: Expected: %s, Actual: %s".formatted(NotificationStatus.ACCEPTED, NotificationStatus.IN_VALIDATION), exception.getMessage());
-  }
-
-  @Test
   void givenNullSendNotificationDTOWhenDownloadAndArchiveSendLegalFactThenThrowSendNotificationNotFoundException() {
     //GIVEN
     String accessToken = "ACCESS_TOKEN";
@@ -1120,49 +1086,6 @@ class SendFacadeServiceImplTest {
     Assertions.assertEquals(
       "[NOTIFICATION_NOT_FOUND] Error in fetching SEND notification by notificationRequestId %s".formatted(notificationRequestId),
       sendNotificationNotFoundException.getMessage()
-    );
-  }
-
-  @Test
-  void givenNotificationInInvalidStatusWhenDownloadAndArchiveSendLegalFactThenThrowInvalidStatusException() {
-    //GIVEN
-    String accessToken = "accessToken";
-    String notificationRequestId = "notificationRequestId";
-    String sendNotificationId = "sendNotificationId";
-    String iun = "IUN";
-    long organizationId = 1L;
-    LegalFactCategoryDTO category = LegalFactCategoryDTO.ANALOG_DELIVERY;
-    String polishedLegalFactId = "sendLegalFact.pdf";
-    String legalFactId = LEGAL_FACT_ID_PREFIX + polishedLegalFactId;
-
-    SendNotificationDTO sendNotificationDTO = new SendNotificationDTO();
-    sendNotificationDTO.setSendNotificationId(sendNotificationId);
-    sendNotificationDTO.setStatus(NotificationStatus.IN_VALIDATION);
-    sendNotificationDTO.setIun(iun);
-    sendNotificationDTO.setOrganizationId(organizationId);
-
-    Mockito.when(sendNotificationServiceMock.findSendNotificationDTOByNotificationRequestId(notificationRequestId))
-      .thenReturn(sendNotificationDTO);
-
-    Mockito.when(sendLegalFactMapperMock.polishLegalFactIdKey(legalFactId))
-      .thenReturn(polishedLegalFactId);
-
-    //WHEN
-    InvalidStatusException invalidStatusException = assertThrows(
-      InvalidStatusException.class,
-      () -> sendService.downloadAndArchiveSendLegalFact(
-        notificationRequestId,
-        category,
-        legalFactId,
-        accessToken
-      )
-    );
-
-    //THEN
-    Assertions.assertNotNull(invalidStatusException);
-    Assertions.assertEquals(
-      "[INVALID_NOTIFICATION_STATUS] Notification status error: Expected: ACCEPTED, Actual: IN_VALIDATION",
-      invalidStatusException.getMessage()
     );
   }
 

--- a/src/test/java/it/gov/pagopa/pu/send/util/DebtPositionUtilsTest.java
+++ b/src/test/java/it/gov/pagopa/pu/send/util/DebtPositionUtilsTest.java
@@ -1,0 +1,19 @@
+package it.gov.pagopa.pu.send.util;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class DebtPositionUtilsTest {
+
+  public static final String NAV = "345670000000000199";
+  public static final String SEGREGATION_CODE = "45";
+
+  @Test
+  public void testExtractSegregationCodeFromNav() {
+    //WHEN
+    String segregationCodeFromNav = DebtPositionUtils.extractSegregationCodeFromNav(NAV);
+    //THEN
+    Assertions.assertEquals(SEGREGATION_CODE, segregationCodeFromNav);
+  }
+
+}

--- a/src/test/java/it/gov/pagopa/pu/send/util/DebtPositionUtilsTest.java
+++ b/src/test/java/it/gov/pagopa/pu/send/util/DebtPositionUtilsTest.java
@@ -9,7 +9,7 @@ public class DebtPositionUtilsTest {
   public static final String SEGREGATION_CODE = "45";
 
   @Test
-  public void testExtractSegregationCodeFromNav() {
+  void testExtractSegregationCodeFromNav() {
     //WHEN
     String segregationCodeFromNav = DebtPositionUtils.extractSegregationCodeFromNav(NAV);
     //THEN


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Added connector for new organization search endpoint (for finding an organization by orgFiscalCode and segregationCode); modified code in CreateNotificationRequest2SendNotificationMapper for searching DebtPosition only if DebtPosition is managed by PU.

#### List of Changes
<!--- Describe your changes in detail -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- Pre-Deploy Test
  - [X] Unit
  - [ ] Integration (Narrow)
- Post-Deploy Test
  - [ ] Isolated Microservice
  - [ ] Broader Integration
  - [ ] Acceptance
  - [ ] Performance & Load

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] PATCH - Bug fix (backwards compatible bug fixes)
- [X] MINOR - New feature (add functionality in a backwards compatible manner)
- [ ] MAJOR - Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] CHORE - Minor Change (fix or feature that don't impact the functionality e.g. Documentation or lint configuration)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
